### PR TITLE
fix: use issue iid for gitlab

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -67,7 +67,7 @@ export default function addSource(context: ExtensionContext, resolver: Resolver)
       let info = JSON.parse(responseText)
       for (let i = 0, len = info.length; i < len; i++) {
         issues.push({
-          id: info[i].id,
+          id: info[i].iid,
           title: info[i].title,
           createAt: new Date(info[i].created_at),
           creator: info[i].author.username,


### PR DESCRIPTION
Gitlab expose 2 ids for issues: the internal unique id and the project's unique id (iid). The internal id is almost never used anywhere visibly and so it makes more sense to use the iid.